### PR TITLE
UPDATE: v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.1.3
+
+### Futures
+
+- Add `Reducer::run_sync`. To use it, enable the `sync` feature.
+
+### Update
+
+- Change type [`ReactiveTask::run`] to [`impl Future<Output=Out> + 'state`]
+
 ## 0.1.2
 
 ### Futures

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "flurx"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-compat",
  "flurx",
@@ -870,18 +870,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flurx"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["elm"]
 categories = ["asynchronous", "data-structures", ]

--- a/examples/store/reducer.rs
+++ b/examples/store/reducer.rs
@@ -1,13 +1,13 @@
 use flurx::prelude::Reducer;
+use flurx::Scheduler;
 use flurx::selector::wait;
 use flurx::store::Store;
 
 #[tokio::main]
 async fn main() {
     let mut store = Store::<usize>::default();
-    let mut reducer = Reducer::<usize>::new(&mut store);
-
-    reducer.schedule(|task| async move {
+    let mut scheduler  = Scheduler::new();
+    scheduler.schedule(|task| async move {
         println!("*** Start ***");
         task.will(wait::until(|state| {
             println!("count: {state}");
@@ -16,6 +16,7 @@ async fn main() {
             .await;
         println!("*** Finish ***");
     });
+    let mut reducer = Reducer::<usize>::new(&mut store, scheduler);
 
     for _ in 0..=5 {
         reducer.dispatch(|state| {

--- a/examples/store/ref_reducer.rs
+++ b/examples/store/ref_reducer.rs
@@ -1,13 +1,13 @@
 use flurx::reducer::RefReducer;
+use flurx::Scheduler;
 use flurx::selector::wait;
 use flurx::store::Store;
 
 #[tokio::main]
 async fn main() {
     let mut store = Store::<String>::default();
-    let mut reducer = RefReducer::new(&mut store);
-
-    reducer.schedule(|task| async move {
+    let mut scheduler  = Scheduler::new();
+    scheduler.schedule(|task| async move {
         println!("*** Start ***");
         task.will(wait::until(|state: &String| {
             println!("state: {state}");
@@ -16,6 +16,7 @@ async fn main() {
             .await;
         println!("*** Finish ***");
     });
+    let mut reducer = RefReducer::new(&mut store, scheduler);
 
     for i in 0..=20 {
         reducer.dispatch(|mut state: String| {

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -8,6 +8,7 @@ mod r#ref;
 #[cfg(test)]
 mod tests {
     use crate::reducer::Reducer;
+    use crate::Scheduler;
     use crate::selector::wait;
     use crate::store::Store;
     use crate::tests::result_event;
@@ -17,16 +18,15 @@ mod tests {
         let mut store = Store::<i32>::default();
 
         let (r1, r2) = result_event::<bool>();
-
-        let mut reducer = Reducer::<i32>::new(&mut store);
-        reducer.schedule(|task| async move {
+        let mut scheduler = Scheduler::new();
+        scheduler.schedule(|task| async move {
             task.will(wait::until(|state| {
                 state == 2
             }))
                 .await;
             r1.set(true);
         });
-
+        let mut reducer = Reducer::<i32>::new(&mut store, scheduler);
         reducer.dispatch(|state| {
             state + 1
         }).await;

--- a/src/reducer/base.rs
+++ b/src/reducer/base.rs
@@ -13,10 +13,10 @@ impl<'state, 'future, State, ScheduleState> ReducerInner<'state, 'future, State,
         State: 'state + 'future,
         ScheduleState: Clone + 'state + 'future
 {
-    pub fn new(store: &'state mut Store<State>) -> ReducerInner<'state, 'future, State, ScheduleState> {
+    pub fn new(store: &'state mut Store<State>, scheduler: Scheduler<'state, 'future, ScheduleState>) -> ReducerInner<'state, 'future, State, ScheduleState> {
         Self {
             store,
-            scheduler: Scheduler::new(),
+            scheduler,
         }
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use crate::error::FutureResult;
 use crate::selector::Selector;
 use crate::task::future::TaskFuture;
@@ -38,15 +39,14 @@ impl<'state, State> ReactiveTask<'state, State> {
     /// });
     /// ```
     #[inline]
-    pub async fn will<Out, Sel>(&self, selector: Sel) -> Out
-        where Sel: Selector<State, Output=Out>,
+    pub fn will<Out, Sel>(&self, selector: Sel) -> impl Future<Output=Out> + 'state
+        where Sel: Selector<State, Output=Out> + 'state,
               State: Clone + 'state
     {
         TaskFuture::<State, Sel, false> {
             state: self.state,
             selector,
         }
-            .await
     }
     
     /// This method will not be made public as the specifications have not yet been finalized.


### PR DESCRIPTION
### Futures

- Add `Reducer::run_sync`. To use it, enable the `sync` feature.

### Update

- Change type [`ReactiveTask::run`] to [`impl Future<Output=Out> + 'state`]